### PR TITLE
Fix the "411 content-length required" error on some jenkins servers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   <artifactId>call-remote-job-plugin</artifactId>
   <name>Call Remote Job Plugin</name>
   <description>Call another jenkins job. and get result. Job is fail when remote job is fail</description>
-  <version>1.0.20-SNAPSHOT</version>
+  <version>1.0.20</version>
   <packaging>hpi</packaging>
   <url>https://wiki.jenkins-ci.org/display/JENKINS/Call+Remote+Job+Plugin</url>
   <scm>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   <artifactId>call-remote-job-plugin</artifactId>
   <name>Call Remote Job Plugin</name>
   <description>Call another jenkins job. and get result. Job is fail when remote job is fail</description>
-  <version>1.0.20</version>
+  <version>1.0.21-SNAPSHOT</version>
   <packaging>hpi</packaging>
   <url>https://wiki.jenkins-ci.org/display/JENKINS/Call+Remote+Job+Plugin</url>
   <scm>


### PR DESCRIPTION
Fix "411 content-length required" for some jenkins servers by adding content length 0 for a post call.